### PR TITLE
Add mock metrics to dashboard

### DIFF
--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -1,14 +1,25 @@
 import React from 'react';
 
+const mockMetrics = [
+  { label: 'Policies enforced', value: 42 },
+  { label: 'Compliant resources', value: 128 },
+  { label: 'Non-compliant resources', value: 5 },
+  { label: 'Last audit', value: '2023-09-01' },
+  // additional mock metrics to flesh out the dashboard
+  { label: 'Policy violations', value: 3 },
+  { label: 'Resources scanned', value: 133 },
+];
+
 export default function Dashboard() {
   return (
     <div className="dashboard">
       <h2>Governance Overview</h2>
       <ul>
-        <li>Policies enforced: 42</li>
-        <li>Compliant resources: 128</li>
-        <li>Non-compliant resources: 5</li>
-        <li>Last audit: 2023-09-01</li>
+        {mockMetrics.map((metric) => (
+          <li key={metric.label}>
+            {metric.label}: {metric.value}
+          </li>
+        ))}
       </ul>
     </div>
   );


### PR DESCRIPTION
## Summary
- show governance metrics from mock data on the dashboard

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685ab5cc7d14832d901919a9394d6980